### PR TITLE
implemented monospace-based interlinear glossing (for github et al)

### DIFF
--- a/docs/text_example/README.md
+++ b/docs/text_example/README.md
@@ -48,13 +48,11 @@ be uttered independently, and the absence of vowel harmony and other
 alternations
 ([Everett and Kern 1997](#references): 332f.):
 
-> (1) Wari'
->
-> | Toc | na | com. |
-> | --- | --- | --- |
-> | drink.SG | 3SG.REAL.NONFUT.ACTIVE | water |
->
-> ‘He is drinking water.’
+
+    (1) Wari'
+        Toc       na                      com.
+        drink.SG  3SG.REAL.NONFUT.ACTIVE  water
+        ‘He is drinking water.’
 
 The corresponding first and second person formatives are *‘ina* and *ma*, 
 respectively. The future forms are *ta’* (1SG), *ra* (2SG), *tara* (3SG), 

--- a/docs/text_example/README_tmpl.md
+++ b/docs/text_example/README_tmpl.md
@@ -48,7 +48,7 @@ be uttered independently, and the absence of vowel harmony and other
 alternations
 ([](sources.bib?ref&with_internal_ref_link=references#cldf:Everett-and-Kern-1997): 332f.):
 
-[](ExampleTable?example_id=1#cldf:igt-2775)
+[](ExampleTable?example_id=1&as_monospace#cldf:igt-2775)
 
 The corresponding first and second person formatives are *‘ina* and *ma*, 
 respectively. The future forms are *ta’* (1SG), *ra* (2SG), *tara* (3SG), 

--- a/src/cldfviz/templates/text/ExampleTable_detail.md
+++ b/src/cldfviz/templates/text/ExampleTable_detail.md
@@ -3,8 +3,11 @@
   `with_primaryText`
   `with_internal_ref_link`
   `example_id`
+  `as_monospace`
 #}
 {% import 'util.md' as util %}
+
+{% if not as_monospace %}
 > ({{ example_id or ctx.id }}) {{ ctx.related('languageReference').name }}{{ util.references(ctx.references, with_internal_ref_link=with_internal_ref_link) }}
 {% if (ctx.cldf.analyzedWord == [] and ctx.cldf.primaryText != None) or with_primaryText %}
 > _{{ ctx.cldf.primaryText }}_
@@ -20,3 +23,18 @@
 {% endif %}
 >
 {% if ctx.cldf.translatedText != None %}> ‘{{ ctx.cldf.translatedText }}’{% endif %}
+
+{% else %}
+{% set pad_len = (example_id or ctx.id)|length+3 %}
+    ({{ example_id or ctx.id }}) {{ ctx.related('languageReference').name }}{{ util.references(ctx.references, with_internal_ref_link=with_internal_ref_link) }}
+{% if (ctx.cldf.analyzedWord == [] and ctx.cldf.primaryText != None) or with_primaryText %}
+    {{ " "*pad_len + ctx.cldf.primaryText }}
+{% endif %}
+{% if ctx.cldf.analyzedWord != [] %}
+{% set obj, gloss = pad_ex(ctx.cldf.analyzedWord, ctx.cldf.gloss) %}
+    {{ " "*pad_len + obj }}
+    {{ " "*pad_len + gloss }}
+{% endif %}
+{% if ctx.cldf.translatedText != None %}
+    {{" "*pad_len}}‘{{ ctx.cldf.translatedText }}’{% endif %}
+{% endif %}


### PR DESCRIPTION
Using tables for aligning interlinear examples is a common strategy in word (and probably HTML, although I have not much experience there -- I do know there's other strategies, too), but it does not make sense to me with Github-flavored markdown (or similar ones), for the following reasons:

* there are superfluous borders around the object and gloss lines
* the object line is printed in bold
* cells are center-aligned, invalidating the original motivation of (left-)aligning words
* there are large gaps between cells
* there is a large gap between the gloss line and the translation

My approach uses four leading spaces for everything in an example, rendering it as a code block, so you get a monospaced font. This can then be exploited to align corresponding object and gloss lines. I added a `pad_ex` function in `text.py` which is then passed as a function dict to the jinja engine (I had to expand some lines, but functionality is preserved). I added a `as_monospace` argument to the ExampleTable template; tables are the default.