### PR TITLE
Template for dictionary entry

### DIFF
--- a/src/cldfviz/templates/text/EntryTable_detail.md
+++ b/src/cldfviz/templates/text/EntryTable_detail.md
@@ -1,0 +1,9 @@
+{#
+  Render a Dictionary entry along with its meaning descriptions.
+#}
+‘{{ ctx.cldf['headword'] }}’, *{{ ctx.cldf['partOfSpeech'] }}*:
+{%- if ctx.senses|length == 1 %}
+ {{ ctx.senses[0].cldf['description'] }}
+{% else %}
+{% for sense in ctx.senses %}{{ " " }}{{ loop.index }}. {{ sense.cldf['description'] }}{% endfor %}{{ "" }}
+{% endif %}

--- a/src/cldfviz/templates/text/EntryTable_detail.md
+++ b/src/cldfviz/templates/text/EntryTable_detail.md
@@ -1,9 +1,9 @@
 {#
   Render a Dictionary entry along with its meaning descriptions.
 #}
-‘{{ ctx.cldf['headword'] }}’, *{{ ctx.cldf['partOfSpeech'] }}*:
+‘{{ ctx.cldf["headword"] }}’, *{{ ctx.cldf["partOfSpeech"] }}*:
 {%- if ctx.senses|length == 1 %}
- {{ ctx.senses[0].cldf['description'] }}
+ {{ ctx.senses[0].cldf["description"] }}
 {% else %}
-{% for sense in ctx.senses %}{{ " " }}{{ loop.index }}. {{ sense.cldf['description'] }}{% endfor %}{{ "" }}
+{% for sense in ctx.senses %}{{ " " }}{{ loop.index }}. {{ sense.cldf["description"] }}{% endfor %}{{ "" }}
 {% endif %}

--- a/tests/Dictionary/Dictionary-metadata.json
+++ b/tests/Dictionary/Dictionary-metadata.json
@@ -1,0 +1,101 @@
+{
+    "@context": [
+        "http://www.w3.org/ns/csvw",
+        {
+            "@language": "en"
+        }
+    ],
+    "dc:conformsTo": "http://cldf.clld.org/v1.0/terms.rdf#Dictionary",
+    "dialect": {
+        "commentPrefix": null
+    },
+    "tables": [
+        {
+            "dc:conformsTo": "http://cldf.clld.org/v1.0/terms.rdf#EntryTable",
+            "dc:extent": 2,
+            "tableSchema": {
+                "columns": [
+                    {
+                        "datatype": {
+                            "base": "string",
+                            "format": "[a-zA-Z0-9_\\-]+"
+                        },
+                        "propertyUrl": "http://cldf.clld.org/v1.0/terms.rdf#id",
+                        "required": true,
+                        "name": "ID"
+                    },
+                    {
+                        "dc:extent": "singlevalued",
+                        "datatype": "string",
+                        "propertyUrl": "http://cldf.clld.org/v1.0/terms.rdf#languageReference",
+                        "required": true,
+                        "name": "Language_ID"
+                    },
+                    {
+                        "dc:extent": "singlevalued",
+                        "datatype": "string",
+                        "propertyUrl": "http://cldf.clld.org/v1.0/terms.rdf#headword",
+                        "required": true,
+                        "name": "Headword"
+                    },
+                    {
+                        "datatype": "string",
+                        "propertyUrl": "http://cldf.clld.org/v1.0/terms.rdf#partOfSpeech",
+                        "required": false,
+                        "name": "Part_Of_Speech"
+                    }
+                ],
+                "primaryKey": [
+                    "ID"
+                ]
+            },
+            "url": "entries.csv"
+        },
+        {
+            "dc:conformsTo": "http://cldf.clld.org/v1.0/terms.rdf#SenseTable",
+            "dc:extent": 3,
+            "tableSchema": {
+                "columns": [
+                    {
+                        "datatype": {
+                            "base": "string",
+                            "format": "[a-zA-Z0-9_\\-]+"
+                        },
+                        "propertyUrl": "http://cldf.clld.org/v1.0/terms.rdf#id",
+                        "required": true,
+                        "name": "ID"
+                    },
+                    {
+                        "datatype": "string",
+                        "propertyUrl": "http://cldf.clld.org/v1.0/terms.rdf#description",
+                        "required": true,
+                        "name": "Description"
+                    },
+                    {
+                        "datatype": "string",
+                        "propertyUrl": "http://cldf.clld.org/v1.0/terms.rdf#entryReference",
+                        "required": true,
+                        "name": "Entry_ID"
+                    }
+                ],
+                "foreignKeys": [
+                    {
+                        "columnReference": [
+                            "Entry_ID"
+                        ],
+                        "reference": {
+                            "resource": "entries.csv",
+                            "columnReference": [
+                                "ID"
+                            ]
+                        }
+                    }
+                ],
+                "primaryKey": [
+                    "ID"
+                ]
+            },
+            "url": "senses.csv"
+        }
+    ]
+}

--- a/tests/Dictionary/entries.csv
+++ b/tests/Dictionary/entries.csv
@@ -1,0 +1,3 @@
+ID,Language_ID,Headword,Part_Of_Speech
+entry-1,uppe1465,Motschegiebschn,noun
+entry-2,uppe1465,Bemme,noun

--- a/tests/Dictionary/senses.csv
+++ b/tests/Dictionary/senses.csv
@@ -1,0 +1,4 @@
+ID,Description,Entry_ID
+sense-1,lady bug,entry-1
+sense-2,sandwich,entry-2
+sense-3,tire of a bicycle,entry-2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,6 +44,12 @@ def Wordlist():
 
 
 @pytest.fixture
+def Dictionary():
+    return Dataset.from_metadata(
+        pathlib.Path(__file__).parent / 'Dictionary' / 'Dictionary-metadata.json')
+
+
+@pytest.fixture
 def Generic():
     return Dataset.from_metadata(
         pathlib.Path(__file__).parent / 'Generic' / 'Generic-metadata.json')

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -49,6 +49,13 @@ The  GL-OSS
 """
 
 
+def test_render_entry(Dictionary):
+    assert render('[ex](EntryTable#cldf:entry-1)', Dictionary) \
+        == '‘Motschegiebschn’, *noun*: lady bug\n'
+    assert render('[ex](EntryTable#cldf:entry-2)', Dictionary) \
+        == '‘Bemme’, *noun*: 1. sandwich 2. tire of a bicycle\n'
+
+
 @pytest.mark.parametrize(
     'comp,query,oid,ds,expected',
     [


### PR DESCRIPTION
Okay, I started filling out the template for generating dictionary entries.

The template itself seems to work fine.  I added a minimal Dictionary dataset to the test suite, which also seems to work fine.

However, the template seems to break the `iter_templates` function?

    $ cldfbench cldfviz.text -l tests/StructureDataset/StructureDataset-metadata.json
    Available templates:
    
    CodeTable detail
    Usage: [<label>](CodeTable#cldf:<object-ID>)
     
     Render a code of a categorical parameter.
     
    Traceback (most recent call last):
      File "./ENV/bin/cldfbench", line 8, in <module>
        sys.exit(main())
      File "./ENV/lib/python3.8/site-packages/cldfbench/__main__.py", line 81, in main
        return args.main(args) or 0
      File "./src/cldfviz/commands/text.py", line 32, in run
        for p, doc, vars in iter_templates():
      File "./src/cldfviz/text.py", line 30, in iter_templates
        parsed_content = env.parse(template_source)
      File "./ENV/lib/python3.8/site-packages/jinja2/environment.py", line 600, in parse
        self.handle_exception(source=source)
      File "./ENV/lib/python3.8/site-packages/jinja2/environment.py", line 925, in handle_exception
        raise rewrite_traceback_stack(source=source)
      File "<unknown>", line 1, in template
    jinja2.exceptions.TemplateSyntaxError: unexpected char '\\' at 89

The template itself isn't even close to 89 lines long and doesn't contain any backslashes anywhere.  So, I'm at a loss here.