### PR TITLE
fallback template definition when using custom templates

### DIFF
--- a/src/cldfviz/text.py
+++ b/src/cldfviz/text.py
@@ -17,9 +17,9 @@ __all__ = ['iter_templates', 'render', 'iter_cldf_image_links', 'CLDFMarkdownLin
 TEMPLATE_DIR = cldfviz.PKG_DIR.joinpath('templates', 'text')
 
 
-def get_env(template_dir=None):
+def get_env(template_dir=None, fallback_template_dir=None):
     loader = jinja2.FileSystemLoader(
-        searchpath=[str(d) for d in nfilter([template_dir, TEMPLATE_DIR])])
+        searchpath=[str(d) for d in nfilter([template_dir, fallback_template_dir, TEMPLATE_DIR])])
     env = jinja2.Environment(loader=loader, trim_blocks=True, lstrip_blocks=True)
 
     def paragraphs(s):
@@ -67,7 +67,7 @@ def pad_ex(obj, gloss):
     return "  ".join(out_obj).strip(), "  ".join(out_gloss).strip()
 
 
-def render(doc, cldf_dict, template_dir=None):
+def render(doc, cldf_dict, template_dir=None, fallback_template_dir=None):
     if isinstance(cldf_dict, Dataset):
         cldf_dict = {None: cldf_dict}
     for prefix, cldf in cldf_dict.items():
@@ -81,7 +81,7 @@ def render(doc, cldf_dict, template_dir=None):
                     table_map[fname] = None
         table_map[cldf.bibname] = 'Source'
         table_map[cldf.tablegroup._fname.name] = 'Metadata'
-        doc = replace_links(get_env(template_dir=template_dir), doc, cldf, prefix, table_map)
+        doc = replace_links(get_env(template_dir=template_dir, fallback_template_dir=fallback_template_dir), doc, cldf, prefix, table_map)
     return doc
 
 


### PR DESCRIPTION
Rationale: when providing a custom template folder, users may want to be able to provide a fallback template folder.

The only use case so far is what I am doing in `pylingdocs`, where the fallback for any template is just the plain text template, but I figure it doesn't hurt to have this here?