### PR TITLE
Pretty-print examples in dataset to HTML

### DIFF
--- a/src/cldfviz/commands/examples.py
+++ b/src/cldfviz/commands/examples.py
@@ -1,0 +1,31 @@
+"""
+Build an HTML file to display exmaples in a CLDF dataset.
+"""
+from clldutils.clilib import PathType
+from pycldf.cli_util import get_dataset, add_dataset
+import jinja2
+
+import cldfviz
+
+
+def register(parser):
+    add_dataset(parser)
+    parser.add_argument(
+        "-o", "--output", type=PathType(type="file", must_exist=False), default=False
+    )
+
+
+def run(args):
+    ds = get_dataset(args)
+
+    examples = list(ds.objects("ExampleTable"))
+    loader = jinja2.FileSystemLoader(
+        searchpath=[str(cldfviz.PKG_DIR / "templates" / "examples")]
+    )
+    env = jinja2.Environment(loader=loader, trim_blocks=True, lstrip_blocks=True)
+    res = env.get_template("examples.html").render(ds=ds, examples=examples)
+    if args.output:
+        args.output.write_text(res, encoding="utf8")
+        print("HTML written to {}".format(args.output))
+    else:
+        print(res)

--- a/src/cldfviz/commands/examples.py
+++ b/src/cldfviz/commands/examples.py
@@ -1,9 +1,9 @@
 """
-Build an HTML file to display exmaples in a CLDF dataset.
+Build an HTML file to display examples in a CLDF dataset.
 """
-from clldutils.clilib import PathType
-from pycldf.cli_util import get_dataset, add_dataset
 import jinja2
+from clldutils.clilib import PathType
+from pycldf.cli_util import add_dataset, get_dataset
 
 import cldfviz
 

--- a/src/cldfviz/templates/examples/examples.html
+++ b/src/cldfviz/templates/examples/examples.html
@@ -1,0 +1,68 @@
+<!doctype html>
+    <html lang="en">
+    <head>
+        <style type="text/css">
+            .primary-text { font-style: italic;}
+            .interlinear-gloss {float: left; margin: 0.25em;}
+            .analyzed-word, .gloss, .interlinear {display: block; margin: 2px 0;}
+            .translated-text { clear: both; }
+            .example::marker {content: "(" attr(value) ") \a0"; }
+        </style>
+    </head>
+    <body>
+        <h1>Examples
+            {% if ds.properties['dc:title'] %}
+            in
+            {% if ds.properties['dc:identifier'] and ds.properties['dc:identifier'].startswith('http') %}
+            "<a href="{{ ds.properties['dc:identifier'] }}">
+                {{ ds.properties['dc:title'] }}
+            </a>""
+            {% else %}
+            "{{ ds.properties['dc:title'] }}"
+            {% endif %}
+            {% endif %}
+        </h1>
+        {% set lspace = namespace(current = None) %}
+        {% for example in examples %}
+
+        {% if example.references %}
+        {% set ref = example.references[0] %}
+        {% set bibkey, pages = split_ref(ref.__str__()) %}
+        {% endif %}
+
+        {% set language = example.related("languageReference") %}
+        <ol class="example">
+            <li class=example id ="{{ example_id or example.id }}">
+                <div class="interlinear">
+                    {% if (lspace.current is defined and lspace.current.id != language.id)%}
+                    {{ language.name }}
+                    {% endif %}{% if example.cldf.primaryText != None %} {% if ref%}(<a href="#source-{{ref.source.id}}">{{ref.source.refkey(year_brackets=None)}}</a>{%if ref.description%}: {{ref.description}}{%endif%})
+                    {%endif%}
+                    <div class="primary-text">{{ example.cldf.primaryText }}</div>
+                    {% endif %}
+                    {% if example.cldf.analyzedWord != [] %}
+                    {% for obj in example.cldf.analyzedWord %}
+                    <div class="interlinear-gloss">
+                      <span class="analyzed-word">{{ obj }}</span>
+                      <span class="gloss">{{ example.cldf.gloss[loop.index-1] }}</span>
+                    </div>
+                    {% endfor %}
+                    {% endif %}
+                    <div class="translated-text">‘{{ example.cldf.translatedText }}’</div>
+                </div>
+            </li>
+        </ol>
+  {% set lspace.current = language %}
+  {% endfor %}
+    </body>
+    <script>
+        function number_examples() {
+            var examples = document.querySelectorAll("li.example");
+            for (var exc = 0; exc < examples.length; exc++) {
+                ex = examples[exc]
+                ex.setAttribute("value", exc + 1)
+            }
+        }
+        number_examples()
+    </script>
+</html>


### PR DESCRIPTION
Rationale: most CLDF tables can be nice to look at for humans, `ExampleTable` being the glaring exception. If you have a CLDF dataset with interlinear text, this is a quick and easy way to consume it.

Usage: `cldfbench cldfviz.examples /path/to/metadata.json --output filename.html`

(I could do away with the numbering javascript and use [CSS counters](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Counter_Styles/Using_CSS_counters) instead, reason I didn't is because the template code is from pylingdocs.)