### PR TITLE
include component in jinja variables

### DIFF
--- a/src/cldfviz/text.py
+++ b/src/cldfviz/text.py
@@ -117,6 +117,7 @@ class TemplateRenderer(CLDFMarkdownText):
         )
         jinja_template = self.env.get_template(tmpl_fname)
         jinja_template.globals.update(self.func_dict)
+        jinja_template.globals.update({"component": fname_or_component})
         return jinja_template.render(**ctx)
 
     def get_tmpl_context(self, ml):


### PR DESCRIPTION
My use case are jinja templates that a) are used for different components, and b) want to link to the entity in question. having the component name available in the template makes this possible.